### PR TITLE
feat: configure interrupts to be edge-triggered by default

### DIFF
--- a/gic-driver/src/version/v2/gicd.rs
+++ b/gic-driver/src/version/v2/gicd.rs
@@ -171,10 +171,9 @@ impl DistributorReg {
         let num_regs = max_interrupts.div_ceil(16) as usize;
         let num_regs = num_regs.min(self.ICFGR.len());
 
-        // Configure all interrupts as level-sensitive (0x0) by default
-        // SGIs are always edge-triggered, but we can set the bits anyway
+        // Configure all interrupts as edge-sensitive (0x1) by default
         for i in 0..num_regs {
-            self.ICFGR[i].set(0);
+            self.ICFGR[i].set(u32::MAX);
         }
     }
 

--- a/gic-driver/src/version/v3/gicd.rs
+++ b/gic-driver/src/version/v3/gicd.rs
@@ -347,9 +347,9 @@ impl DistributorReg {
         let num_regs = max_interrupts.div_ceil(16) as usize;
         let num_regs = num_regs.min(self.ICFGR.len());
 
-        // Configure all interrupts as level-sensitive (0x0) by default
+        // Configure all interrupts as edge-sensitive (0x1) by default
         for i in 0..num_regs {
-            self.ICFGR[i].set(0);
+            self.ICFGR[i].set(u32::MAX);
         }
     }
 


### PR DESCRIPTION
I'm not sure if this is correct, but it works for Starry OS.

Reference:
https://github.com/arceos-org/arm_gicv2/blob/82ed9afc86fa6b5ce461e7bd4034005f1aee6056/src/gic_v2.rs#L231