### PR TITLE
fix(gic-driver): Fix MPIDR mask for current redistributor in GICv3

### DIFF
--- a/gic-driver/src/version/v3/mod.rs
+++ b/gic-driver/src/version/v3/mod.rs
@@ -437,7 +437,7 @@ impl Gic {
     }
 
     fn current_rd(&self) -> NonNull<RedistributorV3> {
-        let want = (MPIDR_EL1.get() & 0xFFF) as u32;
+        let want = (MPIDR_EL1.get() & 0xFFFFFF) as u32;
 
         for rd in self.rd_slice().iter() {
             let affi = unsafe { rd.as_ref() }


### PR DESCRIPTION
Fixed the MPIDR mask used when retrieving the current redistributor in the GICv3 driver, changing it from 0xFFF to 0xFFFFFF to correctly match the bit width of the processor affinity value.